### PR TITLE
⚙️ GitHub Action | CI/CD Buld Error Fix

### DIFF
--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "SIGNED_STORE_FILE=keystore.jks" >> local.properties
 
       - name: Build debug APK
-        run: ./gradlew assembleDebug
+        run: ./Nabi/gradlew assembleDebug
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -30,10 +30,10 @@ jobs:
         run: chmod +x ./Nabi/gradlew
 
       - name: Decode and save keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > presentation/keystore.jks
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ./Nabi/presentation/keystore.jks
 
       - name: Create google-services.json
-        run: echo "$GOOGLE_SERVICES_JSON" > presentation/google-services.json
+        run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json
 
       - name: Create local.properties
         run: |
@@ -49,4 +49,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: nabi-team
-          file: presentation/build/outputs/apk/debug/app-debug.apk
+          file: ./Nabi/presentation/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -1,0 +1,49 @@
+name: Build & upload to Firebase App Distribution
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch: # 수동 실행 옵션
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      LOCAL_PROPERTIES_CONTENTS: ${{ secrets.LOCAL_PROPERTIES_CONTENTS }}
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Decode and save keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > presentation/keystore.jks
+
+      - name: Create google-services.json
+        run: echo "$GOOGLE_SERVICES_JSON" > presentation/google-services.json
+
+      - name: Create local.properties
+        run: |
+          echo "$LOCAL_PROPERTIES_CONTENTS" > local.properties
+          echo "SIGNED_STORE_FILE=keystore.jks" >> local.properties
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          groups: nabi-team
+          file: presentation/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -27,7 +27,7 @@ jobs:
           java-version: '17'
 
       - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
+        run: chmod +x ./Nabi/gradlew
 
       - name: Decode and save keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > presentation/keystore.jks

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -55,4 +55,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: nabi-team
-          file: ./Nabi/presentation/build/outputs/apk/release/app-release.apk
+          file: ./Nabi/presentation/build/outputs/apk/release/Nabi-release.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -40,10 +40,10 @@ jobs:
           echo "$LOCAL_PROPERTIES_CONTENTS" > ./Nabi/local.properties
           echo "SIGNED_STORE_FILE=keystore.jks" >> ./Nabi/local.properties
 
-      - name: Build debug APK
+      - name: Build release APK
         run: |
           cd ./Nabi
-          ./gradlew assembleDebug
+          ./gradlew assembleRelease
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
@@ -51,4 +51,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: nabi-team
-          file: ./Nabi/presentation/build/outputs/apk/debug/app-debug.apk
+          file: ./Nabi/presentation/build/outputs/apk/debug/app-release.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -37,11 +37,13 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "$LOCAL_PROPERTIES_CONTENTS" > local.properties
-          echo "SIGNED_STORE_FILE=keystore.jks" >> local.properties
+          echo "$LOCAL_PROPERTIES_CONTENTS" > ./Nabi/local.properties
+          echo "SIGNED_STORE_FILE=keystore.jks" >> ./Nabi/local.properties
 
       - name: Build debug APK
-        run: ./Nabi/gradlew assembleDebug
+        run: |
+          cd ./Nabi
+          ./gradlew assembleDebug
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -38,17 +38,6 @@ jobs:
           echo "Checking JKS format..."
           keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype JKS || echo "JKS format verification failed"
 
-          echo "Checking PKCS12 format..."
-          keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype PKCS12 || echo "PKCS12 format verification failed"
-
-      - name: Convert keystore to JKS if necessary
-        run: |
-          # Check if keystore is PKCS12 format and convert to JKS if needed
-          if keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype PKCS12 > /dev/null 2>&1; then
-            echo "Converting PKCS12 keystore to JKS..."
-            keytool -importkeystore -srckeystore ./Nabi/presentation/keystore.jks -srcstoretype PKCS12 -destkeystore ./Nabi/presentation/keystore.jks -deststoretype JKS
-          fi
-
       - name: Create google-services.json
         run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json
 

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -32,18 +32,12 @@ jobs:
       - name: Decode and save keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ./Nabi/presentation/keystore.jks
 
-      - name: Print decoded keystore file (for debugging)
-        run: |
-          echo "Decoded keystore content:"
-          cat ./Nabi/presentation/keystore.jks
-
       - name: Create google-services.json
         run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json
 
       - name: Create local.properties
         run: |
           echo "$LOCAL_PROPERTIES_CONTENTS" > ./Nabi/local.properties
-          echo "SIGNED_STORE_FILE=keystore.jks" >> ./Nabi/local.properties
 
       - name: Build release APK
         run: |
@@ -56,4 +50,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: nabi-team
-          file: ./Nabi/presentation/build/outputs/apk/debug/app-release.apk
+          file: ./Nabi/presentation/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - develop
-  workflow_dispatch: # 수동 실행 옵션
+  workflow_dispatch:
 
 jobs:
   build:
@@ -31,6 +31,11 @@ jobs:
 
       - name: Decode and save keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ./Nabi/presentation/keystore.jks
+
+      - name: Verify keystore
+        run: |
+          ls -alh ./Nabi/presentation/
+          keytool -list -v -keystore ./Nabi/presentation/keystore.jks || echo "Keystore verification failed"
 
       - name: Create google-services.json
         run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -3,6 +3,9 @@ name: Build & upload to Firebase App Distribution
 on:
   push:
     branches: [ develop ]
+  pull_request:
+    branches:
+      - develop
   workflow_dispatch: # 수동 실행 옵션
 
 jobs:
@@ -15,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '17'
 
       - name: Grant execute permission for gradlew
@@ -44,6 +47,6 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: nabi-team
           file: presentation/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -32,6 +32,11 @@ jobs:
       - name: Decode and save keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ./Nabi/presentation/keystore.jks
 
+      - name: Print decoded keystore file (for debugging)
+        run: |
+          echo "Decoded keystore content:"
+          cat ./Nabi/presentation/keystore.jks
+
       - name: Create google-services.json
         run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json
 

--- a/.github/workflows/app-distribution-ci-cd.yaml
+++ b/.github/workflows/app-distribution-ci-cd.yaml
@@ -1,4 +1,4 @@
-name: Build & upload to Firebase App Distribution
+name: Build & Upload to Firebase App Distribution
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - develop
-  workflow_dispatch:
+  workflow_dispatch: # 수동 실행 옵션
 
 jobs:
   build:
@@ -35,14 +35,25 @@ jobs:
       - name: Verify keystore
         run: |
           ls -alh ./Nabi/presentation/
-          keytool -list -v -keystore ./Nabi/presentation/keystore.jks || echo "Keystore verification failed"
+          echo "Checking JKS format..."
+          keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype JKS || echo "JKS format verification failed"
+
+          echo "Checking PKCS12 format..."
+          keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype PKCS12 || echo "PKCS12 format verification failed"
+
+      - name: Convert keystore to JKS if necessary
+        run: |
+          # Check if keystore is PKCS12 format and convert to JKS if needed
+          if keytool -list -v -keystore ./Nabi/presentation/keystore.jks -storetype PKCS12 > /dev/null 2>&1; then
+            echo "Converting PKCS12 keystore to JKS..."
+            keytool -importkeystore -srckeystore ./Nabi/presentation/keystore.jks -srcstoretype PKCS12 -destkeystore ./Nabi/presentation/keystore.jks -deststoretype JKS
+          fi
 
       - name: Create google-services.json
         run: echo "$GOOGLE_SERVICES_JSON" > ./Nabi/presentation/google-services.json
 
       - name: Create local.properties
-        run: |
-          echo "$LOCAL_PROPERTIES_CONTENTS" > ./Nabi/local.properties
+        run: echo "$LOCAL_PROPERTIES_CONTENTS" > ./Nabi/local.properties
 
       - name: Build release APK
         run: |

--- a/Nabi/data/src/main/java/com/nabi/data/mapper/HomeMapper.kt
+++ b/Nabi/data/src/main/java/com/nabi/data/mapper/HomeMapper.kt
@@ -15,7 +15,7 @@ object HomeMapper {
                     RecentFiveDiary(
                         content = diary.content,
                         diaryEntryDate = diary.diaryEntryDate,
-                        emotion = diary.emotion
+                        emotion = diary.emotion ?: ""
                     )
                 }
             )

--- a/Nabi/data/src/main/java/com/nabi/data/model/home/RecentFiveDiary.kt
+++ b/Nabi/data/src/main/java/com/nabi/data/model/home/RecentFiveDiary.kt
@@ -9,5 +9,5 @@ data class RecentFiveDiary(
     @SerializedName("diaryEntryDate")
     val diaryEntryDate: String,
     @SerializedName("emotion")
-    val emotion: String
+    val emotion: String?
 )

--- a/Nabi/presentation/build.gradle.kts
+++ b/Nabi/presentation/build.gradle.kts
@@ -28,6 +28,14 @@ android {
         buildConfigField("String", "BASE_URL", "\"${properties.getProperty("BASE_URL")}\"")
     }
 
+    applicationVariants.all {
+        outputs.all {
+            val outputImpl = this as com.android.build.gradle.internal.api.ApkVariantOutputImpl
+            val newFileName = "Nabi-${name}.apk"
+            outputImpl.outputFileName = newFileName
+        }
+    }
+
     signingConfigs {
         create("release") {
             keyAlias = properties["SIGNED_KEY_ALIAS"] as String?

--- a/Nabi/presentation/build.gradle.kts
+++ b/Nabi/presentation/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         minSdk = 29
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "0.0.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "KAKAO_NATIVE_KEY", "\"${properties.getProperty("KAKAO_NATIVE_KEY")}\"")

--- a/Nabi/presentation/build.gradle.kts
+++ b/Nabi/presentation/build.gradle.kts
@@ -28,8 +28,18 @@ android {
         buildConfigField("String", "BASE_URL", "\"${properties.getProperty("BASE_URL")}\"")
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = properties["SIGNED_KEY_ALIAS"] as String?
+            keyPassword = properties["SIGNED_KEY_PASSWORD"] as String?
+            storeFile = properties["SIGNED_STORE_FILE"]?.let { file(it) }
+            storePassword = properties["SIGNED_STORE_PASSWORD"] as String?
+        }
+    }
+
     buildTypes {
-        release {
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -37,6 +47,7 @@ android {
             )
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -48,15 +59,6 @@ android {
         viewBinding = true
         dataBinding = true
         buildConfig = true
-    }
-
-    signingConfigs {
-        getByName("debug") {
-            keyAlias = properties["SIGNED_KEY_ALIAS"] as String?
-            keyPassword = properties["SIGNED_KEY_PASSWORD"] as String?
-            storeFile = properties["SIGNED_STORE_FILE"]?.let { file(it) }
-            storePassword = properties["SIGNED_STORE_PASSWORD"] as String?
-        }
     }
 }
 


### PR DESCRIPTION
## 🍀 Summary
<!-- 어떤 내용의 PR인가요? -->

<br>

## 💫 Issue Number
<!-- 이슈 번호를 작성해주세요 -->
#36 
<br>

## ☑️ Checklist
<!-- PR 요청 시 체크해주세요 -->
- [x] Base Branch
- [x] Assignees
- [x] Labels
- [x] Issue Number
- [x] Conflict Resolve
<br>

## 📌 Troubleshooting
<!-- 전달하고 싶은 내용이 있나요? -->

### 문제 1. 노드 버전 문제
```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3, actions/setup-java@v3. 
For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

**해결 방법**
action/setup-java@v3 -> v4로 수정

<br>

### 문제 2.  Cannot access './gradlew': No such file or directory
```
chmod: cannot access './gradlew': No such file or directory
```

**해결 방법**
```
- name: Grant execute permission for gradlew
        run: chmod +x ./gradlew
```
~~./gradlew~~ -> ./Nabi/gradlew

<br>

### 문제 3. Repository Root Dir에서 build.gradle.kts, build.gradle 파일을 찾을 수 없음
```
Directory '/home/runner/work/Nabi-Android/Nabi-Android' does not contain a Gradle build.
A Gradle build should contain a 'settings.gradle' or 'settings.gradle.kts' file in its root directory. 
It may also contain a 'build.gradle' or 'build.gradle.kts' file.
```

**해결 방법**
```
 - name: Build debug APK
        run: ./gradlew assembleRelease
```
~~./gradlew assembleRelease~~ -> ./Nabi/gradlew assembleRelease


<br>

### 문제 4. Failed to read key keyStore 
```
Execution failed for task ':presentation:packageRelease'.
A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable
com.android.ide.common.signing.KeytoolException: Failed to read key keystore from store "/home/runner/work/Nabi-Android/Nabi-Android/Nabi/presentation/keystore.jks": toDerInputStream rejects tag type 35
```

**해결 방법**
KeyStore.jks 파일 자체를 Base64로 인코딩


<br>

### 문제 5. Firebase App Distribution - Not Found APK
```
Error: File ./Nabi/presentation/build/outputs/apk/release/Nabi-release.apk does not exist: verify that file points to a binary
```

**해결 방법**
```
// build.gradle에 추가
applicationVariants.all {
        outputs.all {
            val outputImpl = this as com.android.build.gradle.internal.api.ApkVariantOutputImpl
            val newFileName = "Nabi-${name}.apk"
            outputImpl.outputFileName = newFileName
        }
    }
```
<br>

### 문제 6. Firebase App Distribution - Does not have permission
```
Error: failed to upload release. HTTP Error: 403, The caller does not have permission
```

**해결 방법**
Google Cloud Console의 Project와 Firebaes Console의 Project를 연결해줘야 하는데
Firebase Console Project와 이미 연결된 Google Cloud Project가 존재했음.
그래서 새로 생성한 프로젝트 제거 후 기존 프로젝트로 연결한다음
Firebase App Distribution Admin 역할이 있는 Service Account 생성 후 Key(.json) 발급 받아 사용하는걸로 해결함

<br>
